### PR TITLE
Update compiler.cmd

### DIFF
--- a/packages/protoscript/src/compiler.cmd
+++ b/packages/protoscript/src/compiler.cmd
@@ -1,2 +1,2 @@
 @echo off
-node .\node_modules\protoscript\dist\compiler.js %*
+node %~p0compiler.js %*


### PR DESCRIPTION
To support monorepos on windows, where protoscript might not actually be located in the project root's own node_modules, but in the monorepo's node_modules, use %~p0 to find compiler.js relative to the cmd file instead of relative to the current working directory